### PR TITLE
Go back to using new for CP437Codec on OS X

### DIFF
--- a/src/dfinstanceosx.mm
+++ b/src/dfinstanceosx.mm
@@ -61,8 +61,6 @@ THE SOFTWARE.
 #define VM_REGION_BASIC_INFO_64 VM_REGION_BASIC_INFO
 #endif /* MACH64 */
 
-static CP437Codec cp437Codec;
-
 DFInstanceOSX::DFInstanceOSX(QObject* parent)
     : DFInstance(parent)
 {
@@ -126,7 +124,8 @@ QString DFInstanceOSX::read_string(const VIRTADDR &addr) {
     //}
 
     buf.truncate(buf.indexOf(QChar('\0')));
-    return cp437Codec.toUnicode(buf);
+    CP437Codec *c = new CP437Codec();
+    return c->toUnicode(buf);
 }
 
 int DFInstanceOSX::write_string(const VIRTADDR &addr, const QString &str) {


### PR DESCRIPTION
QT takes care of destroying it internally.
