### PR TITLE
Naive write_string for OSX

### DIFF
--- a/inc/dfinstanceosx.h
+++ b/inc/dfinstanceosx.h
@@ -28,6 +28,8 @@ THE SOFTWARE.
 #include "dfinstance.h"
 #include "dwarf.h"
 
+#include <QHash>
+
 class MemoryLayout;
 
 class DFInstanceOSX : public DFInstance {
@@ -59,6 +61,10 @@ protected:
     uint calculate_checksum();
     vm_map_t m_task;
     QString m_loc_of_dfexe;
+
+private:
+    uintptr_t get_string(const QString &str);
+    QHash<QString, uintptr_t> m_string_cache;
 };
 
 #endif // DFINSTANCE_H

--- a/inc/utils.h
+++ b/inc/utils.h
@@ -211,4 +211,3 @@ static inline bool has_flag(int flag, int flags){
 //}
 
 #endif // UTILS_H
-


### PR DESCRIPTION
A naive port (read: copy-paste) of the Linux `write_string` to OSX. One difference: it uses straight `malloc` instead of a remote `mmap2`. I have zero idea how to do that :) I took care to make sure that if `malloc` returns a pointer to an address outside the range of `VIRTADDR`, the application won't blow up (didn't test it though).

I've been using this for just a few minutes now, seems to work so far.

Fixes https://github.com/splintermind/Dwarf-Therapist/issues/10
