### PR TITLE
fixed INSTALLS+= bin, fixed make uninstall

### DIFF
--- a/dwarftherapist.pro
+++ b/dwarftherapist.pro
@@ -89,16 +89,21 @@ else:unix {
     target.path = /usr/bin
     INSTALLS += target
 
-    bin.path = /usr/bin; cp dist/dwarftherapist $(INSTALL_ROOT)/usr/bin/dwarftherapist
-    bin.files += bin/release/DwarfTherapist; chmod +x $(INSTALL_ROOT)/usr/bin/dwarftherapist
+    bin.path = /usr/bin
+    bin.files += dist/dwarftherapist
     INSTALLS += bin
+    
+    bin_mod.path = /usr/bin
+    bin_mod.extra = chmod +x $(INSTALL_ROOT)/usr/bin/dwarftherapist
+    INSTALLS += bin_mod
 
     application.path = /usr/share/applications
-    application.files = dist/dwarftherapist.desktop
+    application.files += dist/dwarftherapist.desktop
     INSTALLS += application
 
     doc.path = /usr/share/doc/dwarftherapist
-    doc.extra = cp LICENSE $(INSTALL_ROOT)/usr/share/doc/dwarftherapist/copyright; cp README.md $(INSTALL_ROOT)/usr/share/doc/dwarftherapist/README.Debian
+    doc.files += LICENSE.txt
+    doc.files += README.md
     INSTALLS += doc
 
     icon.path = /usr/share/pixmaps
@@ -106,14 +111,13 @@ else:unix {
     icon.files += img/dwarftherapist.xpm
     INSTALLS += icon
 
-    share.path = /usr/share/dwarftherapist
-    share.extra = mkdir -p $(INSTALL_ROOT)/usr/share/dwarftherapist/etc; \
-        mkdir -p $(INSTALL_ROOT)/usr/share/dwarftherapist/etc/memory_layouts; \
-        mkdir -p $(INSTALL_ROOT)/usr/share/dwarftherapist/etc/memory_layouts/linux; \
-        cp etc/game_data.ini $(INSTALL_ROOT)/usr/share/dwarftherapist/etc; \
-        cp etc/memory_layouts/linux/* $(INSTALL_ROOT)/usr/share/dwarftherapist/etc/memory_layouts/linux
+    memory_layouts.path = /usr/share/dwarftherapist/etc/memory_layouts/linux
+    memory_layouts.files += etc/memory_layouts/linux/*
+    INSTALLS += memory_layouts
 
-    INSTALLS += share
+    game_data.path = /usr/share/dwarftherapist/etc
+    game_data.files += etc/game_data.ini
+    INSTALLS += game_data
 }
 
 # Translation files


### PR DESCRIPTION
removed bin/release/DwarfFortress redundance (installed my target)
added bin_mod to make dwarffortress executable by default
split share so make uninstall can remove all files (folder /usr/share/etc/memory_layouts still remains)
changed doc so make uninstall can remove files (generation of debian docs is handled by debian/
