### PR TITLE
Use process_vm_{read,write}v instead of ptrace

### DIFF
--- a/inc/dfinstance.h
+++ b/inc/dfinstance.h
@@ -67,7 +67,7 @@ public:
     bool looks_like_vector_of_pointers(const VIRTADDR &addr);
 
     // revamped memory reading
-    virtual int read_raw(const VIRTADDR &addr, int bytes, QByteArray &buf) = 0;
+    virtual int read_raw(const VIRTADDR &addr, size_t bytes, QByteArray &buf) = 0;
     virtual BYTE read_byte(const VIRTADDR &addr);
     virtual WORD read_word(const VIRTADDR &addr);
     virtual VIRTADDR read_addr(const VIRTADDR &addr);
@@ -123,7 +123,7 @@ public:
     void set_memory_layout(MemoryLayout * layout) { m_layout = layout; }
 
     // Writing
-    virtual int write_raw(const VIRTADDR &addr, const int &bytes,
+    virtual int write_raw(const VIRTADDR &addr, const size_t &bytes,
                           void *buffer) = 0;
     virtual int write_string(const VIRTADDR &addr, const QString &str) = 0;
     virtual int write_int(const VIRTADDR &addr, const int &val) = 0;

--- a/inc/dfinstancelinux.h
+++ b/inc/dfinstancelinux.h
@@ -40,11 +40,13 @@ public:
     // factory ctor
     bool find_running_copy(bool connect_anyway = false);
     QVector<VIRTADDR> enumerate_vector(const uint &addr);
-    int read_raw(const VIRTADDR &addr, int bytes, QByteArray &buffer);
+    int read_raw_ptrace(const VIRTADDR &addr, size_t bytes, QByteArray &buffer);
+    int read_raw(const VIRTADDR &addr, size_t bytes, QByteArray &buffer);
     QString read_string(const VIRTADDR &addr);
 
     // Writing
-    int write_raw(const VIRTADDR &addr, const int &bytes, void *buffer);
+    int write_raw_ptrace(const VIRTADDR &addr, const size_t &bytes, void *buffer);
+    int write_raw(const VIRTADDR &addr, const size_t &bytes, void *buffer);
     int write_string(const VIRTADDR &addr, const QString &str);
     int write_int(const VIRTADDR &addr, const int &val);
 


### PR DESCRIPTION
This approximately doubles the speed of Dwarf Therapist on Linux, and
fixes #73.
