### PR TITLE
Fix parallel installation on linux

### DIFF
--- a/dwarftherapist.pro
+++ b/dwarftherapist.pro
@@ -96,6 +96,7 @@ else:unix {
 
     bin_mod.path = /usr/bin
     bin_mod.extra = chmod +x $(INSTALL_ROOT)/usr/bin/dwarftherapist
+    bin_mod.depends = install_bin
     INSTALLS += bin_mod
 
     application.path = /usr/share/applications


### PR DESCRIPTION
Installation will fail if install_bin_mod happens before install_bin.
Add proper dependencies.

Signed-off-by: Kirill A. Shutemov kirill@shutemov.name
