### PR TITLE
Remove OS-specific entries from .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,48 +16,6 @@ moc_*.h
 .qmake.cache
 translations/qtmobility_untranslated.ts
 translations/qtmobility_*.qm
- 
-#Symbian specific
-*.mmp
-*.pkg
-bld.inf*
-ABLD.BAT
-*.mk
-*.rss
-*.sis
-*.loc
-*.sisx
-.make.cache
-qmakepluginstubs
- 
-#Carbide project files
-*.project
-*.cproject
-*.settings
-plugin_commonU.def
- 
-#Visual Studio files
-*.sln
-*.vcproj
-*.suo
-*.ncb
-*.user
- 
-#QtCreator project files
-*.pro.user
-=======
-*.pro.user*
-*~
- 
-#Failed patch
-*.orig
-*.rej
 
-#Windows Specific
 *.exe
 *.dll
-Thumbs.db
-desktop.ini
-
-#OSX
-.DS_Store


### PR DESCRIPTION
.gitignore should only store items that are generated by the code in the
repository. If your operating systems generates temporary files, put
those in your .gitignore_global.
