### PR TITLE
Optimize performance - avoid QRegExp

### DIFF
--- a/inc/dwarf.h
+++ b/inc/dwarf.h
@@ -400,7 +400,7 @@ public:
 
     QHash<short, int> get_thoughts() {return m_thoughts;}
 
-    Q_INVOKABLE bool has_preference(QString pref_name, QString category = "", bool exactMatch = true);
+    Q_INVOKABLE bool has_preference(QString pref_name, QString category = "");
     Q_INVOKABLE bool find_preference(QString pref_name,QString category_name);
     Q_INVOKABLE bool has_thought(short id) {return m_thoughts.contains(id);}
     Q_INVOKABLE bool has_health_issue(int id, int idx = -1);

--- a/src/dwarf.cpp
+++ b/src/dwarf.cpp
@@ -2805,31 +2805,17 @@ Reaction *Dwarf::get_reaction()
 }
 
 bool Dwarf::find_preference(QString pref_name, QString category_name){
-    return has_preference(pref_name,category_name,false);
+    return has_preference(pref_name,category_name);
 }
 
-bool Dwarf::has_preference(QString pref_name, QString category, bool exactMatch){
-    QRegExp str_search("(" + pref_name + ")",Qt::CaseInsensitive, QRegExp::RegExp);
-    QString pref = "";
-
+bool Dwarf::has_preference(QString pref_name, QString category){
     if(category.isEmpty()){
-        if(exactMatch){
-            return m_pref_search.contains(pref_name, Qt::CaseInsensitive);
-        }else{
-            return m_pref_search.contains(str_search);
-        }
-        return false;
+        return m_pref_search.contains(pref_name, Qt::CaseInsensitive);
     }else{
         if(!m_grouped_preferences.keys().contains(category))
             return false;
-        if(exactMatch){
-            return m_grouped_preferences.value(category)->contains(pref_name,Qt::CaseInsensitive);
-        }else{
-            pref = m_grouped_preferences.value(category)->join(" ");
-            if(pref.contains(str_search))
-                return true;
-        }
-        return false;
+        QString pref = m_grouped_preferences.value(category)->join(" ");
+        return pref.contains(pref_name);
     }
 }
 

--- a/src/models/dwarfmodelproxy.cpp
+++ b/src/models/dwarfmodelproxy.cpp
@@ -131,7 +131,7 @@ bool DwarfModelProxy::filterAcceptsRow(int source_row, const QModelIndex &source
             //if no match, check prefs
             if(!matches){
                 Dwarf *d = m->get_dwarf_by_id(dwarf_id);
-                matches = d->has_preference(m_filter_text,"",false);
+                matches = d->has_preference(m_filter_text,"");
             }
         }
     }else {
@@ -157,7 +157,7 @@ bool DwarfModelProxy::filterAcceptsRow(int source_row, const QModelIndex &source
                 //if no match, check prefs
                 if(!matches){
                     Dwarf *d = m->get_dwarf_by_id(dwarf_id);
-                    matches = d->has_preference(m_filter_text,"",false);
+                    matches = d->has_preference(m_filter_text,"");
                 }
             }
         }

--- a/src/preference.cpp
+++ b/src/preference.cpp
@@ -142,10 +142,5 @@ int Preference::matches(Preference *role_pref, Dwarf *d){
 }
 
 int Preference::exact_matches(QString searchval){
-    QRegExp str_search("(" + searchval + ")",Qt::CaseInsensitive,QRegExp::RegExp);
-    if(m_name.contains(str_search)){
-        return str_search.captureCount();
-    }else{
-        return 0;
-    }
+    return m_name.count(searchval, Qt::CaseInsensitive);
 }

--- a/src/roledialog.cpp
+++ b/src/roledialog.cpp
@@ -1034,7 +1034,11 @@ void roleDialog::item_double_clicked(QTreeWidgetItem *item, int col){
 
 void roleDialog::search_prefs(QString val){
     val = "(" + val.replace(" ", "|") + ")";
-    QRegExp filter = QRegExp(val,Qt::CaseInsensitive, QRegExp::RegExp);
+#if QT_VERSION >= 0x050000
+    QRegularExpression filter(val, QRegularExpression::CaseInsensitiveOption);
+#else
+    QRegExp filter(val, Qt::CaseInsensitive);
+#endif
     int hidden;
     for(int i = 0; i < ui->treePrefs->topLevelItemCount(); i++){
         hidden = 0;


### PR DESCRIPTION
Use string searching wherever possible instead of constructing temporary
regular expressions, and if a regexp is required, use QRegularExpression
instead.

These changes reduce loading time from ~3.5 seconds to ~2.3 seconds.
