### PR TITLE
src/dfinstanceosx.mm: Use m_loc_of_dfexe to find DF

### DIFF
--- a/src/dfinstanceosx.mm
+++ b/src/dfinstanceosx.mm
@@ -150,7 +150,7 @@ int DFInstanceOSX::write_int(const VIRTADDR &addr, const int &val) {
 
 QString DFInstanceLinux::calculate_checksum() {
     // ELF binaries don't seem to store a linker timestamp, so just MD5 the file.
-    QFile proc(QString("/proc/%1/exe").arg(m_pid));
+    QFile proc(m_loc_of_dfexe);
     QCryptographicHash hash(QCryptographicHash::Md5);
     if (!proc.open(QIODevice::ReadOnly) || !hash.addData(&proc)) {
         LOGE << "FAILED TO READ DF EXECUTABLE";


### PR DESCRIPTION
... instead of trying to open /proc which doesn't exist on OSX.
fixes #119.
