### PR TITLE
dwarftherapist.pro: Remove QMAKE_CXX

### DIFF
--- a/dwarftherapist.pro
+++ b/dwarftherapist.pro
@@ -24,7 +24,6 @@ else {
     OBJECTS_DIR = bin$${DIR_SEPARATOR}release
 }
 
-QMAKE_CXX += $$(CXX)
 QMAKE_CXXFLAGS += $$(CXXFLAGS)
 QMAKE_LFLAGS += $$(LDFLAGS)
 


### PR DESCRIPTION
All the qmake functions are broken; none can actually test for an empty
variable.

as it turns out, the "correct" "qmake" way to set a simple compiler is to use a qmakespec.
