### PR TITLE
Log to stderr on Linux systems.

### DIFF
--- a/src/dwarftherapist.cpp
+++ b/src/dwarftherapist.cpp
@@ -137,7 +137,13 @@ void DwarfTherapist::setup_logging() {
 
     //setup logging
     m_log_mgr = new LogManager(this);
-    TruncatingFileLogger *log = m_log_mgr->add_logger("log/run.log");
+    TruncatingFileLogger *log = m_log_mgr->add_logger(
+#ifdef Q_OS_LINUX
+    ""
+#else
+    "log/run.log"
+#endif
+    );
     if (log) {
         LogAppender *app = m_log_mgr->add_appender("core", log, LL_TRACE);
         if (app) {

--- a/src/truncatingfilelogger.cpp
+++ b/src/truncatingfilelogger.cpp
@@ -111,20 +111,25 @@ TruncatingFileLogger::TruncatingFileLogger(const QString &path, QObject *parent)
     , m_path(path)
     , m_file(0)
 {
-    QFileInfo info(m_path);
-    info.makeAbsolute();
-    QDir d(info.absolutePath());
+    if (path.isEmpty()) {
+        m_file = new QFile(this);
+        m_file->open(stderr, QIODevice::WriteOnly | QIODevice::Text);
+    } else {
+        QFileInfo info(m_path);
+        info.makeAbsolute();
+        QDir d(info.absolutePath());
 
-    if (!d.exists()) {
-        d.mkpath(d.absolutePath());
-    }
-    m_path = info.absoluteFilePath();
+        if (!d.exists()) {
+            d.mkpath(d.absolutePath());
+        }
+        m_path = info.absoluteFilePath();
 
-    // open the path we were given...
-    m_file = new QFile(m_path);
-    if (!m_file->open(QIODevice::WriteOnly | QIODevice::Truncate |
-                      QIODevice::Text)) {
-        qCritical() << "Could not open " << m_path << " for writing!" << m_file->errorString();
+        // open the path we were given...
+        m_file = new QFile(m_path);
+        if (!m_file->open(QIODevice::WriteOnly | QIODevice::Truncate |
+                          QIODevice::Text)) {
+            qCritical() << "Could not open " << m_path << " for writing!" << m_file->errorString();
+        }
     }
 }
 


### PR DESCRIPTION
This fixes #114 and removes the write to the current directory that
places files where users may not expect.

I assume that Linux users are familiar enough with the command line to
run a program and output errors to a file via 2>file or similar.
