### PR TITLE
Use weak symbols for process_vm_* functions.

### DIFF
--- a/inc/dfinstancelinux.h
+++ b/inc/dfinstancelinux.h
@@ -73,6 +73,7 @@ private:
     VIRTADDR m_inject_addr;
     VIRTADDR m_alloc_start, m_alloc_end;
     QHash<QString, VIRTADDR> m_string_cache;
+    bool m_warned_glibc;
 };
 
 #endif // DFINSTANCE_H


### PR DESCRIPTION
This allows DT to run on pre-2.15 glibcs.

now, I haven't actually _tested_ these changes, not having a pre-2.15 glibc. they should work fine though.
