### PR TITLE
More backend changes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 Makefile*
 object_script.*
 
+*.exe
 debug/*
 release/*
 ui/*.h

--- a/BUILDING.rst
+++ b/BUILDING.rst
@@ -8,7 +8,7 @@ Download the Qt Creator IDE and open the dwarftherapist.pro project.
 
 You must perform one of the following steps to have DT run properly in Qt Creator. They are listed in approximate order of recommendation:
 
-- Change default build step: Run ``make`` (aka jom) with arguments ``first install``.
+- Change default build step: Run ``make`` (aka nmake, jom) with arguments ``first install``.
 - Set the *run* working directory to ``%{sourceDir}``.
 - Disable shadow build.
 - Manually copy the ``share`` directory from the clone to the build location, i.e. ``%{buildDir}`` or ``%{buildDir}/<build type>``.

--- a/dwarftherapist.pro
+++ b/dwarftherapist.pro
@@ -40,14 +40,16 @@ win32 {
 
     DEFINES += NOMINMAX
 
+    PRO_FILE_PWD = $$replace(_PRO_FILE_PWD_, /, \\)
+
     check_dirs.path = $$DESTDIR
     check_dirs.extra = if not exist $$DESTDIR\\share\\memory_layouts\\windows mkdir "$$DESTDIR\\share\\memory_layouts\\windows";
 
     copy_game_data.path = $$DESTDIR
-    copy_game_data.extra = copy /Y "share\\game_data.ini" ".\\$$DESTDIR\\share";
+    copy_game_data.extra = copy /Y "$$PRO_FILE_PWD\\share\\game_data.ini" ".\\$$DESTDIR\\share";
 
     copy_mem_layouts.path = $$DESTDIR
-    copy_mem_layouts.extra = copy /Y "share\\memory_layouts\\windows\\*" ".\\$$DESTDIR\\share\\memory_layouts\\windows";
+    copy_mem_layouts.extra = copy /Y "$$PRO_FILE_PWD\\share\\memory_layouts\\windows\\*" ".\\$$DESTDIR\\share\\memory_layouts\\windows";
 
     INSTALLS += check_dirs
     INSTALLS += copy_game_data

--- a/inc/attribute.h
+++ b/inc/attribute.h
@@ -29,10 +29,9 @@ THE SOFTWARE.
 #include "qcolor.h"
 
 class Attribute {
-
 public:    
     Attribute();
-    Attribute(int id, int value, int display_value, int max, int cost_to_improve = 500, int desc_index = 0, QString desc = "");
+    Attribute(ATTRIBUTES_TYPE id, int value, int display_value, int max, int cost_to_improve = 500, int desc_index = 0, QString desc = "");
 
     int id(){return m_id;}
     ATTRIBUTES_TYPE att_type(){return static_cast<ATTRIBUTES_TYPE>(m_id);}
@@ -61,7 +60,7 @@ public:
     static const QColor color_affected_by_syns() {return QColor(0, 60, 128, 135);}
 
 private:
-    int m_id;
+    ATTRIBUTES_TYPE m_id;
     int m_value; //raw value including permanent syndrome effects
     float m_value_potential;
     float m_value_balanced;

--- a/inc/dfinstance.h
+++ b/inc/dfinstance.h
@@ -57,7 +57,7 @@ public:
     WORD dwarf_race_id() {return m_dwarf_race_id;}
     QList<MemoryLayout*> get_layouts() { return m_memory_layouts.values(); }
     QDir get_df_dir() { return m_df_dir; }
-    short current_year() {return (short)m_current_year;}
+    WORD current_year() {return m_current_year;}
     WORD dwarf_civ_id() {return m_dwarf_civ_id;}
 
     // brute force memory scanning methods

--- a/inc/dwarf.h
+++ b/inc/dwarf.h
@@ -119,28 +119,28 @@ public:
     //! return the raw happiness score for this dwarf
     Q_INVOKABLE int get_raw_happiness() {return m_raw_happiness;}
     //! return specific attribute values
-    Q_INVOKABLE int strength() {return attribute((int)AT_STRENGTH);}
-    Q_INVOKABLE int agility() {return attribute((int)AT_AGILITY);}
-    Q_INVOKABLE int toughness() {return attribute((int)AT_TOUGHNESS);}
-    Q_INVOKABLE int endurance() {return attribute((int)AT_ENDURANCE);}
-    Q_INVOKABLE int recuperation() {return attribute((int)AT_RECUPERATION);}
-    Q_INVOKABLE int disease_resistance() {return attribute((int)AT_DISEASE_RESISTANCE);}
-    Q_INVOKABLE int willpower() {return attribute((int)AT_WILLPOWER);}
-    Q_INVOKABLE int memory() {return attribute((int)AT_MEMORY);}
-    Q_INVOKABLE int focus() {return attribute((int)AT_FOCUS);}
-    Q_INVOKABLE int intuition() {return attribute((int)AT_INTUITION);}
-    Q_INVOKABLE int patience() {return attribute((int)AT_PATIENCE);}
-    Q_INVOKABLE int empathy() {return attribute((int)AT_EMPATHY);}
-    Q_INVOKABLE int social_awareness() {return attribute((int)AT_SOCIAL_AWARENESS);}
-    Q_INVOKABLE int creativity() {return attribute((int)AT_CREATIVITY);}
-    Q_INVOKABLE int musicality() {return attribute((int)AT_MUSICALITY);}
-    Q_INVOKABLE int analytical_ability() {return attribute((int)AT_ANALYTICAL_ABILITY);}
-    Q_INVOKABLE int linguistic_ability() {return attribute((int)AT_LINGUISTIC_ABILITY);}
-    Q_INVOKABLE int spatial_sense() {return attribute((int)AT_SPATIAL_SENSE);}
-    Q_INVOKABLE int kinesthetic_sense() {return attribute((int)AT_KINESTHETIC_SENSE);}
+    Q_INVOKABLE int strength() {return attribute(AT_STRENGTH);}
+    Q_INVOKABLE int agility() {return attribute(AT_AGILITY);}
+    Q_INVOKABLE int toughness() {return attribute(AT_TOUGHNESS);}
+    Q_INVOKABLE int endurance() {return attribute(AT_ENDURANCE);}
+    Q_INVOKABLE int recuperation() {return attribute(AT_RECUPERATION);}
+    Q_INVOKABLE int disease_resistance() {return attribute(AT_DISEASE_RESISTANCE);}
+    Q_INVOKABLE int willpower() {return attribute(AT_WILLPOWER);}
+    Q_INVOKABLE int memory() {return attribute(AT_MEMORY);}
+    Q_INVOKABLE int focus() {return attribute(AT_FOCUS);}
+    Q_INVOKABLE int intuition() {return attribute(AT_INTUITION);}
+    Q_INVOKABLE int patience() {return attribute(AT_PATIENCE);}
+    Q_INVOKABLE int empathy() {return attribute(AT_EMPATHY);}
+    Q_INVOKABLE int social_awareness() {return attribute(AT_SOCIAL_AWARENESS);}
+    Q_INVOKABLE int creativity() {return attribute(AT_CREATIVITY);}
+    Q_INVOKABLE int musicality() {return attribute(AT_MUSICALITY);}
+    Q_INVOKABLE int analytical_ability() {return attribute(AT_ANALYTICAL_ABILITY);}
+    Q_INVOKABLE int linguistic_ability() {return attribute(AT_LINGUISTIC_ABILITY);}
+    Q_INVOKABLE int spatial_sense() {return attribute(AT_SPATIAL_SENSE);}
+    Q_INVOKABLE int kinesthetic_sense() {return attribute(AT_KINESTHETIC_SENSE);}
     //! attribute value from id
-    Q_INVOKABLE int attribute(int attrib_id) {return get_attribute(attrib_id).get_value();}
-    Attribute get_attribute(int id);
+    Q_INVOKABLE int attribute(ATTRIBUTES_TYPE attrib_id) {return get_attribute(attrib_id).get_value();}
+    Attribute get_attribute(ATTRIBUTES_TYPE id);
 
     //! return this dwarf's squad reference id
     Q_INVOKABLE int squad_id(bool original = false) { return (original ? m_squad_id : m_pending_squad_id);}
@@ -605,7 +605,7 @@ private:
     void read_soul_aspects();
     void read_skills();
     void read_attributes();
-    void load_attribute(VIRTADDR &addr, int id);
+    void load_attribute(VIRTADDR &addr, ATTRIBUTES_TYPE id);
     void read_personality();    
     void read_turn_count();
     void read_animal_type();

--- a/inc/gamedatareader.h
+++ b/inc/gamedatareader.h
@@ -109,8 +109,8 @@ public:
     void refresh_opt_plans();
     void refresh_facets();
 
-    QString get_attribute_name(int id){return m_attribute_names.value(id);}
-    QHash<int,QString> get_attributes(){return m_attribute_names;}
+    QString get_attribute_name(ATTRIBUTES_TYPE id){return m_attribute_names.value(id);}
+    QHash<ATTRIBUTES_TYPE,QString> get_attributes(){return m_attribute_names;}
     ATTRIBUTES_TYPE get_attribute_type(QString name){return m_attributes_by_name.value(name);}
 
     QString get_string_for_key(QString key);
@@ -175,7 +175,7 @@ private:
     QHash<int, QString> m_skill_levels;
 
     QHash<int, int> m_attribute_levels;
-    QHash<int, QString> m_attribute_names;
+    QHash<ATTRIBUTES_TYPE, QString> m_attribute_names;
     QHash<QString, ATTRIBUTES_TYPE> m_attributes_by_name;
     QList<QPair<int,QString> > m_ordered_attribute_names;
 

--- a/inc/global_enums.h
+++ b/inc/global_enums.h
@@ -16,6 +16,7 @@ typedef enum {
 } DWARF_HAPPINESS;
 
 typedef enum {
+    AT_NONE = -1,
     AT_STRENGTH = 0,
     AT_AGILITY=1,
     AT_TOUGHNESS=2,

--- a/inc/utils.h
+++ b/inc/utils.h
@@ -68,19 +68,19 @@ static inline int decode_int(const QByteArray &arr) {
 static inline QByteArray encode_skillpattern(short skill, short exp, short rating) {
     QByteArray bytes;
     bytes.reserve(6);
-    bytes[0] = (uchar)skill;
-    bytes[1] = (uchar)(skill >> 8);
-    bytes[2] = (uchar)exp;
-    bytes[3] = (uchar)(exp >> 8);
-    bytes[4] = (uchar)rating;
-    bytes[5] = (uchar)(rating >> 8);
+    bytes[0] = static_cast<uchar>(skill);
+    bytes[1] = static_cast<uchar>(skill >> 8);
+    bytes[2] = static_cast<uchar>(exp);
+    bytes[3] = static_cast<uchar>(exp >> 8);
+    bytes[4] = static_cast<uchar>(rating);
+    bytes[5] = static_cast<uchar>(rating >> 8);
     return bytes;
 }
 
 static inline QString by_char(QByteArray arr) {
     QString out;
     for(int i=0; i < arr.size(); i++) {
-        out += QString::number((uchar)arr.at(i), 16);
+        out += QString::number(arr.at(i), 16);
         out += " ";
     }
     return out;
@@ -164,10 +164,10 @@ template <class T> class vPtr
 {
 public:
     static T* asPtr(QVariant v){
-        return (T*)v.value<void *>();
+        return static_cast<T*>(v.value<void *>());
     }
     static QVariant asQVariant(T* ptr){
-        return qVariantFromValue((void*) ptr);
+        return qVariantFromValue(static_cast<void*>(ptr));
     }
 };
 

--- a/src/attribute.cpp
+++ b/src/attribute.cpp
@@ -29,7 +29,7 @@ THE SOFTWARE.
 QHash<int, QVector<QString> > Attribute::m_display_descriptions;
 
 Attribute::Attribute()
-    : m_id(-1)
+    : m_id(AT_NONE)
     , m_value(0)
     , m_value_potential(-1)
     , m_value_balanced(-1)
@@ -43,7 +43,7 @@ Attribute::Attribute()
 {
 }
 
-Attribute::Attribute(int id, int value, int display_value, int max, int cost_to_improve, int desc_index, QString desc)
+Attribute::Attribute(ATTRIBUTES_TYPE id, int value, int display_value, int max, int cost_to_improve, int desc_index, QString desc)
         : m_id(id)
         , m_value(value)
         , m_value_potential(-1)

--- a/src/dfinstance.cpp
+++ b/src/dfinstance.cpp
@@ -624,7 +624,7 @@ void DFInstance::load_role_ratings(){
     QVector<double> pref_values;
 
     foreach(Dwarf *d, m_labor_capable_dwarves){
-        foreach(int id, GameDataReader::ptr()->get_attributes().keys()){
+        foreach(ATTRIBUTES_TYPE id, GameDataReader::ptr()->get_attributes().keys()){
             attribute_values.append(d->get_attribute(id).get_balanced_value());
             attribute_raw_values.append(d->get_attribute(id).get_value());
         }

--- a/src/dwarf.cpp
+++ b/src/dwarf.cpp
@@ -1827,19 +1827,18 @@ void Dwarf::read_attributes() {
     //read the physical attributes
     VIRTADDR addr = m_address + m_mem->dwarf_offset("physical_attrs");
     for(int i=0; i<6; i++){
-        load_attribute(addr,i);
+        load_attribute(addr, static_cast<ATTRIBUTES_TYPE>(i));
     }
     //read the mental attributes, but append to our array (augment the key by the number of physical attribs)
     int phys_size = m_attributes.size();
     addr = m_first_soul + m_mem->soul_detail("mental_attrs");
     for(int i=0; i<13; i++){
-        load_attribute(addr,i+phys_size);
+        load_attribute(addr, static_cast<ATTRIBUTES_TYPE>(i+phys_size));
     }
 }
 
-void Dwarf::load_attribute(VIRTADDR &addr, int id){
+void Dwarf::load_attribute(VIRTADDR &addr, ATTRIBUTES_TYPE id){
     int cti = 500;
-    ATTRIBUTES_TYPE att_id = static_cast<ATTRIBUTES_TYPE>(id);
     QPair<int,QString> desc; //index, description of descriptor
 
     int value = (int)m_df->read_int(addr);
@@ -1849,19 +1848,19 @@ void Dwarf::load_attribute(VIRTADDR &addr, int id){
     //apply any permanent syndrome changes to the raw/base value
     int perm_add = 0;
     int perm_perc = 1;
-    if(m_attribute_mods_perm.contains(att_id)){
-        perm_perc = m_attribute_mods_perm.value(att_id).first;
+    if(m_attribute_mods_perm.contains(id)){
+        perm_perc = m_attribute_mods_perm.value(id).first;
         value *= perm_perc;
-        perm_add = m_attribute_mods_perm.value(att_id).second;
+        perm_add = m_attribute_mods_perm.value(id).second;
         value += perm_add;
     }
     //apply temp syndrome changes to the display value
-    if(m_attribute_mods_temp.contains(att_id)){
+    if(m_attribute_mods_temp.contains(id)){
         display_value *= perm_perc;
-        display_value *= m_attribute_mods_temp.value(att_id).first;
+        display_value *= m_attribute_mods_temp.value(id).first;
 
         display_value += perm_add;
-        display_value += m_attribute_mods_temp.value(att_id).second;
+        display_value += m_attribute_mods_temp.value(id).second;
     }else{
         display_value *= perm_perc;
         display_value += perm_add;
@@ -1869,7 +1868,7 @@ void Dwarf::load_attribute(VIRTADDR &addr, int id){
 
     if(m_caste){
         cti = m_caste->get_attribute_cost_to_improve(id);
-        desc = m_caste->get_attribute_descriptor_info(att_id, display_value);
+        desc = m_caste->get_attribute_descriptor_info(id, display_value);
     }
     Attribute a = Attribute(id, value, display_value, limit, cti, desc.first, desc.second);
 
@@ -1877,14 +1876,14 @@ void Dwarf::load_attribute(VIRTADDR &addr, int id){
     if(!m_is_baby && !m_is_animal)
         a.calculate_balanced_value();
 
-    if(m_attribute_syndromes.contains(att_id))
-        a.set_syn_names(m_attribute_syndromes.value(att_id));
+    if(m_attribute_syndromes.contains(id))
+        a.set_syn_names(m_attribute_syndromes.value(id));
 
     m_attributes.append(a);
     addr+=0x1c;
 }
 
-Attribute Dwarf::get_attribute(int id){
+Attribute Dwarf::get_attribute(ATTRIBUTES_TYPE id){
     if(id < m_attributes.count())
         return m_attributes.at(id);
     else
@@ -2684,13 +2683,11 @@ float Dwarf::calc_role_rating(Role *m_role){
 
     //ATTRIBUTES
     if(m_role->attributes.count()>0){
-        int attrib_id = 0;
-        aspect_value = 0;
         foreach(QString name, m_role->attributes.uniqueKeys()){
             a = m_role->attributes.value(name);
             weight = a->weight;
 
-            attrib_id = GameDataReader::ptr()->get_attribute_type(name.toUpper());
+            ATTRIBUTES_TYPE attrib_id = GameDataReader::ptr()->get_attribute_type(name.toUpper());
             aspect_value = get_attribute(attrib_id).rating(true);
 
             if(a->is_neg)

--- a/src/gamedatareader.cpp
+++ b/src/gamedatareader.cpp
@@ -100,19 +100,19 @@ GameDataReader::GameDataReader(QObject *parent)
     QStringList attribute_names;
     for(int i = 0; i < attributes; ++i) {
         m_data_settings->setArrayIndex(i);        
-        int id = m_data_settings->value("id",0).toInt();
+        ATTRIBUTES_TYPE id = static_cast<ATTRIBUTES_TYPE>(m_data_settings->value("id",0).toInt());
         QString name = m_data_settings->value("name","unknown").toString();
         m_attribute_names.insert(id,name);
-        m_attributes_by_name.insert(name.toUpper(),static_cast<ATTRIBUTES_TYPE>(id));
+        m_attributes_by_name.insert(name.toUpper(),id);
         attribute_names << name;
     }
     m_data_settings->endArray();  
 
     qSort(attribute_names);
     foreach(QString sorted_name, attribute_names) {
-        foreach(int id, m_attribute_names.uniqueKeys()) {
+        foreach(ATTRIBUTES_TYPE id, m_attribute_names.uniqueKeys()) {
             if (m_attribute_names.value(id) == sorted_name) {
-                m_ordered_attribute_names << QPair<int, QString>(id, m_attribute_names.value(id));
+                m_ordered_attribute_names << QPair<ATTRIBUTES_TYPE, QString>(id, m_attribute_names.value(id));
                 break;
             }
         }

--- a/src/grid_view/attributecolumn.cpp
+++ b/src/grid_view/attributecolumn.cpp
@@ -38,7 +38,7 @@ AttributeColumn::AttributeColumn(const QString &title, ATTRIBUTES_TYPE type, Vie
     , m_attribute_type(type)
 {
     if (title.isEmpty()) // Determine title based on type if no title was passed in
-        m_title = GameDataReader::ptr()->get_attribute_name((int)type);
+        m_title = GameDataReader::ptr()->get_attribute_name(type);
 }
 
 AttributeColumn::AttributeColumn(QSettings &s, ViewColumnSet *set, QObject *parent)
@@ -55,7 +55,7 @@ AttributeColumn::AttributeColumn(const AttributeColumn &to_copy)
 
 QStandardItem *AttributeColumn::build_cell(Dwarf *d) {
     QStandardItem *item = init_cell(d);
-    Attribute a = d->get_attribute((int)m_attribute_type);
+    Attribute a = d->get_attribute(m_attribute_type);
     short rawVal = a.get_value();
     QString descriptor = a.get_descriptor();
     float rating = a.rating() * 100.0f;    

--- a/src/gridviewdialog.cpp
+++ b/src/gridviewdialog.cpp
@@ -647,7 +647,7 @@ void GridViewDialog::add_attribute_column() {
         return;
     QAction *a = qobject_cast<QAction*>(QObject::sender());
     ATTRIBUTES_TYPE type = static_cast<ATTRIBUTES_TYPE>(a->data().toInt());
-    new AttributeColumn(GameDataReader::ptr()->get_attribute_name((int)type), type, m_active_set, m_active_set);
+    new AttributeColumn(GameDataReader::ptr()->get_attribute_name(type), type, m_active_set, m_active_set);
     draw_columns_for_set(m_active_set);
 }
 


### PR DESCRIPTION
- Update .gitignore
- Adjust BUILDING.rst
- Import LaTeX docs and delete compiled PDF and old HTML docs.
- Add build_pass scope to dwarftherapist.pro.
- Modify attributes to use ATTRIBUTES_TYPE enum instead of ints and
  casts.
- Fix vector enumeration memory leak.
- Move OSX authorization to subclass.
- Remove unused code from utils.h, add quint64 support to hexify.
- Remove useless concurrency that blocked the main thread anyways.
- Modify DFInstanceLinux to move out process_vm logic to separate
  function and use syscall() instead of glibc wrappers; this way, they
  will work regardless of glibc version.
- Rewrite DFInstanceLinux::write_raw_ptrace to only read excess data
  instead of the entire write.
- Fix various windeployqt.sh issues.
