### PR TITLE
Fix: make get_noble_color return exactly 1 QColor

### DIFF
--- a/src/fortressentity.cpp
+++ b/src/fortressentity.cpp
@@ -215,11 +215,9 @@ QString FortressEntity::get_noble_positions(int hist_id, bool is_male){
 
 QColor FortressEntity::get_noble_color(int hist_id){
     QList<position> p = m_nobles.values(hist_id);
-    if(p.size() > 1)
-        return m_noble_colors.value(MULTIPLE);
-    else
+    if(p.size() == 1){
         return p[0].highlight;
-
+    }
     return m_noble_colors.value(MULTIPLE); //unknown
 }
 


### PR DESCRIPTION
get_noble_color was crashing accessing an empty list
when m_nobles.values() returned an empty list.

If m_nobles.values() returns 1 color return that, otherwise
if it returns no colors or many colors return a default value.
