### PR TITLE
2 fixes for OS X

### DIFF
--- a/dwarftherapist.pro
+++ b/dwarftherapist.pro
@@ -72,9 +72,9 @@ build_pass {
         share.path = Contents/MacOS/share        
         QMAKE_BUNDLE_DATA += share
 
-        layouts.path = Contents/MacOS/share/memory_layouts/osx
-        layouts.files += share/memory_layouts/osx/*
-        QMAKE_BUNDLE_DATA += layouts
+        memory_layouts.path = Contents/MacOS/share/memory_layouts/osx
+        memory_layouts.files += $$files(share/memory_layouts/osx/*)
+        QMAKE_BUNDLE_DATA += memory_layouts
     }
     else:unix {
         message(Setting up for Linux)
@@ -112,7 +112,7 @@ build_pass {
         INSTALLS += icon
 
         memory_layouts.path = /usr/share/dwarftherapist/memory_layouts/linux
-        memory_layouts.files += share/memory_layouts/linux/*
+        memory_layouts.files += $$files(share/memory_layouts/linux/*)
         INSTALLS += memory_layouts
     }
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -34,6 +34,7 @@ THE SOFTWARE.
 #include "dfinstance.h"
 
 int main(int argc, char *argv[]) {
+    QCoreApplication::setSetuidAllowed(true);
     if(!DFInstance::authorize()){
         return 0;
     }


### PR DESCRIPTION
Hi! I couldn't get Dwarf Therapist to compile on Mac -- the copying of memory layouts was incorrect in dwarftherapist.pro.

When I got it to compile, it refused to run because on Mac, it needs to be setuid, and Qt complains about that. Fixed that as well.
