### PR TITLE
Fix crash when looking at Skill Legend panel immediately on startup

### DIFF
--- a/src/statetableview.cpp
+++ b/src/statetableview.cpp
@@ -756,7 +756,9 @@ void StateTableView::mouseMoveEvent(QMouseEvent *event) {
             else
                 m_dragging = false;
         }
-        m_proxy->redirect_tooltip(idx);
+        if(m_proxy){
+          m_proxy->redirect_tooltip(idx);
+        }
     }
     QTreeView::mouseMoveEvent(event);
 }


### PR DESCRIPTION
It is possible for m_proxy to be unallocated immediately after startup.
This patch guards against this by checking m_proxy before use.
