### PR TITLE
Make the .pro file respect linux PREFIX convention

### DIFF
--- a/BUILDING.rst
+++ b/BUILDING.rst
@@ -57,12 +57,22 @@ Building
     qmake # Qt 4 on most other distros
     make -j$(nproc) # Run as many jobs as processing units
 
+To configure where DT is installed, pass the PREFIX variable, for example:
+
+::
+    qmake PREFIX=~/.local
+
 For instructions on exactly where to find qmake and how to invoke it on other distros, consult your distribution's documentation.
 
 This will take 2–10 minutes, depending on CPU.
 Get a cup of coffee.
-Once your build is complete, run::
 
+Once your build is complete, run make install. Use sudo if installing into the
+default /usr/local directory (i.e, if you didn't pass the PREFIX variable to
+qmake)
+
+    make install
+    OR
     sudo make install
 
 If you want, you can now remove the folder you cloned from github.

--- a/dwarftherapist.pro
+++ b/dwarftherapist.pro
@@ -78,21 +78,24 @@ build_pass {
     }
     else:unix {
         message(Setting up for Linux)
+        isEmpty(PREFIX) {
+            PREFIX = /usr/local
+        }
         HEADERS += inc/dfinstancelinux.h
         SOURCES += src/dfinstancelinux.cpp
 
-        target.path = /usr/bin
+        target.path = $$PREFIX/bin
         INSTALLS += target
 
-        bin.path = /usr/bin
+        bin.path = $$PREFIX/bin
         bin.files += dist/dwarftherapist
         INSTALLS += bin
 
-        application.path = /usr/share/applications
+        application.path = $$PREFIX/share/applications
         application.files += dist/dwarftherapist.desktop
         INSTALLS += application
 
-        doc.path = /usr/share/doc/dwarftherapist
+        doc.path = $$PREFIX/share/doc/dwarftherapist
         doc.files += LICENSE.txt
         doc.files += README.rst
         system("printf 'Checking for pdflatex... '; if ! command -v pdflatex; then echo 'not found'; exit 1; fi") {
@@ -106,12 +109,12 @@ build_pass {
         }
         INSTALLS += doc
 
-        icon.path = /usr/share/pixmaps
+        icon.path = $$PREFIX/share/pixmaps
         icon.files += img/dwarftherapist.png
         icon.files += img/dwarftherapist.xpm
         INSTALLS += icon
 
-        memory_layouts.path = /usr/share/dwarftherapist/memory_layouts/linux
+        memory_layouts.path = $$PREFIX/share/dwarftherapist/memory_layouts/linux
         memory_layouts.files += $$files(share/memory_layouts/linux/*)
         INSTALLS += memory_layouts
     }


### PR DESCRIPTION
Fixes #225

This allows the user to install DT in any directory they choose, for
example:

qmake PREFIX=~/.local
