### PR TITLE
Make unauthorized DT instances quit correctly

### DIFF
--- a/src/dfinstanceosx.mm
+++ b/src/dfinstanceosx.mm
@@ -63,6 +63,9 @@ THE SOFTWARE.
 DFInstanceOSX::DFInstanceOSX(QObject* parent)
     : DFInstanceNix(parent)
 {
+    // This makes the unauthorized DT instance quit at the proper time.
+    // No, fflush(stdout) does not work.
+    puts("");
     if(!authorize()) {
         exit(1);
     }


### PR DESCRIPTION
Fixes first part of #199 
I have no idea why this works. Ideally, something like #165 should be used instead.
