### PR TITLE
No need for ZIP compression

### DIFF
--- a/dwarftherapist.pro
+++ b/dwarftherapist.pro
@@ -13,6 +13,7 @@ CONFIG += debug_and_release \
 
 QMAKE_CXXFLAGS += $$(CXXFLAGS)
 QMAKE_LFLAGS += $$(LDFLAGS)
+QMAKE_RESOURCE_FLAGS += -no-compress
 
 INCLUDEPATH += inc \
     inc$${DIR_SEPARATOR}models \


### PR DESCRIPTION
Resource files are ZIP compressed by default, but PNG files are alredy compressed,
