### PR TITLE
add explicit QHash include

### DIFF
--- a/inc/skill.h
+++ b/inc/skill.h
@@ -25,6 +25,7 @@ THE SOFTWARE.
 
 #include <QString>
 #include <QColor>
+#include <QHash>
 
 class Skill
 {


### PR DESCRIPTION
Build currently fails for me using Qt 5.5.0 with multiple errors about `QHash` in `skill.h`:

```
In file included from src/skill.cpp:23:0:
inc/skill.h:95:12: error: ‘QHash’ does not name a type
     static QHash<int,int> m_experience_levels;
            ^
```

I suspect, but haven't been able to confirm, that this is due to changes in the include hierarchy in Qt itself. I.e., in Qt 5.0.2 (which Travis is using), `<QHash>` is indirectly included by some other header, but isn't anymore in Qt 5.5.0. Either way, adding `#include <QHash>` to `skill.h` (which is the only thing this pull request does) makes the project build for me.
