### PR TITLE
Add function to get dwarf attribute max in scripts

### DIFF
--- a/inc/dwarf.h
+++ b/inc/dwarf.h
@@ -252,7 +252,7 @@ public:
     Q_INVOKABLE int kinesthetic_sense() {return attribute(AT_KINESTHETIC_SENSE);}
     //! attribute value from id
     Q_INVOKABLE int attribute(ATTRIBUTES_TYPE attrib_id) {return get_attribute(attrib_id).get_value();}
-	Q_INVOKABLE int attribute_maximum(ATTRIBUTES_TYPE attrib_id) {return (int)get_attribute(attrib_id).max();}
+    Q_INVOKABLE int attribute_maximum(ATTRIBUTES_TYPE attrib_id) {return (int)get_attribute(attrib_id).max();}
     Attribute get_attribute(ATTRIBUTES_TYPE id);
 
     //! return this dwarf's squad reference id

--- a/inc/dwarf.h
+++ b/inc/dwarf.h
@@ -252,6 +252,7 @@ public:
     Q_INVOKABLE int kinesthetic_sense() {return attribute(AT_KINESTHETIC_SENSE);}
     //! attribute value from id
     Q_INVOKABLE int attribute(ATTRIBUTES_TYPE attrib_id) {return get_attribute(attrib_id).get_value();}
+	Q_INVOKABLE int attribute_maximum(ATTRIBUTES_TYPE attrib_id) {return (int)get_attribute(attrib_id).max();}
     Attribute get_attribute(ATTRIBUTES_TYPE id);
 
     //! return this dwarf's squad reference id


### PR DESCRIPTION
so people can script filter dwarves by how special they could ever be, and not just how special they currently are

More specific example: you only want to see dwarves who can train endurance past 4000, so you only put the dwarves who can become unstoppable in your military. Or your hand-cranked pump corps.
